### PR TITLE
TASK: Avoid processing empty string in extractHtmlTags

### DIFF
--- a/Classes/Eel/IndexingHelper.php
+++ b/Classes/Eel/IndexingHelper.php
@@ -157,6 +157,8 @@ class IndexingHelper implements ProtectedContextAwareInterface
      */
     public function extractHtmlTags($string): array
     {
+        if (!$string || trim($string) === "") return [];
+        
         // prevents concatenated words when stripping tags afterwards
         $string = str_replace(['<', '>'], [' <', '> '], $string);
         // strip all tags except h1-6


### PR DESCRIPTION
PHP8 is a bit more strict in what argument can be passed to str_replace, see https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor/pull/386